### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -18,6 +18,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       digests: ${{ steps.hash.outputs.digests }}


### PR DESCRIPTION
Potential fix for [https://github.com/akabarki76/myblog/security/code-scanning/1](https://github.com/akabarki76/myblog/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `build` job. Based on the provided workflow, the `build` job only reads and generates artifacts, so it likely only requires `contents: read` permissions. This change will ensure that the `build` job has the minimal permissions necessary to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
